### PR TITLE
Subject filter removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-startup-lib",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "arangojs": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "FRMS Center of Excellence startup package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/services/jetstreamService.ts
+++ b/src/services/jetstreamService.ts
@@ -150,7 +150,7 @@ async function createConsumer(functionName: string, jsm: JetStreamManager, consu
   const consumerCfg: Partial<ConsumerConfig> = {
     ack_policy: AckPolicy[typedAckPolicy],
     durable_name: functionName,
-    filter_subjects: streamSubjects,
+    // filter_subjects: streamSubjects, Require Nats Version 2.10 to be released. Slated for a few months.
   };
   await jsm.consumers.add(consumerStreamName, consumerCfg);
   logger.log('Connected Consumer to Consumer Stream');


### PR DESCRIPTION
Removed subject Filter, which requires a yet unreleased version of NATS (Version 2.10) to be implemented. 