### PR TITLE
chore: bump coe-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-startup-lib",
-      "version": "2.2.0-alpha.0",
+      "version": "2.2.0-alpha.1",
       "license": "ISC",
       "dependencies": {
-        "@frmscoe/frms-coe-lib": "^4.0.0-rc.2",
+        "@frmscoe/frms-coe-lib": "^4.0.0-rc.4",
         "arangojs": "^8.3.0",
         "fast-json-stringify": "^5.8.0",
         "ioredis": "^5.3.2",
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@frmscoe/frms-coe-lib": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.2/019bce1ac0baffda9b8b750a63f17e956cbcd787",
-      "integrity": "sha512-W4L+E7c9J+Kd2Efde+xZJw+AyhC7mJgualJGtP9FFmQEzJdUNLemtBEwV5Z5LanqbCt6x2Gvvf9zrKVkqLFocA==",
+      "version": "4.0.0-rc.4",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.4/98b307424811f121ff34b082bad627fa7b82d26a",
+      "integrity": "sha512-fYrXY0RL8DX9X45F2sskzzEAcXdLkAMJLAWIZ6W0piKnOhqLmKsmLXdfxzE9Ki/joIONRA9oXbN5BFSv8T7A2Q==",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
         "@grpc/grpc-js": "^1.9.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "2.1.3",
+  "version": "2.2.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-startup-lib",
-      "version": "2.1.3",
+      "version": "2.2.0-alpha.0",
       "license": "ISC",
       "dependencies": {
-        "@frmscoe/frms-coe-lib": "^3.0.0",
+        "@frmscoe/frms-coe-lib": "^4.0.0-rc.2",
         "arangojs": "^8.3.0",
         "fast-json-stringify": "^5.8.0",
         "ioredis": "^5.3.2",
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@frmscoe/frms-coe-lib": {
-      "version": "3.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/3.0.0/c0e4d551f4d122b56227de2825c6299a0453350a",
-      "integrity": "sha512-DowIXlXCHiTiU5GlLezVaxFeXmR7E1zTnUt9HAky1dhfgwJ4XEhTiT/J+63YKpvTf29PH/uJN0iPnNiLUT4ppQ==",
+      "version": "4.0.0-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.2/019bce1ac0baffda9b8b750a63f17e956cbcd787",
+      "integrity": "sha512-W4L+E7c9J+Kd2Efde+xZJw+AyhC7mJgualJGtP9FFmQEzJdUNLemtBEwV5Z5LanqbCt6x2Gvvf9zrKVkqLFocA==",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
         "@grpc/grpc-js": "^1.9.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "2.1.3",
+  "version": "2.2.0-alpha.0",
   "description": "FRMS Center of Excellence startup package library",
   "main": "lib/index.js",
   "repository": {
@@ -20,7 +20,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@frmscoe/frms-coe-lib": "^3.0.0",
+    "@frmscoe/frms-coe-lib": "^4.0.0-rc.2",
     "arangojs": "^8.3.0",
     "fast-json-stringify": "^5.8.0",
     "ioredis": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-startup-lib",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "FRMS Center of Excellence startup package library",
   "main": "lib/index.js",
   "repository": {
@@ -20,7 +20,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@frmscoe/frms-coe-lib": "^4.0.0-rc.2",
+    "@frmscoe/frms-coe-lib": "^4.0.0-rc.4",
     "arangojs": "^8.3.0",
     "fast-json-stringify": "^5.8.0",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
Update to rc.2 for coe-lib. Allows the handleResponse message to be able to serialise the message properly with the updated protofile upstream