### PR TITLE
refactor: bump lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-startup-lib",
-  "version": "2.3.0-rc.3",
+  "version": "2.3.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-startup-lib",
-      "version": "2.3.0-rc.3",
+      "version": "2.3.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "^5.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-startup-lib",
-  "version": "2.3.0-rc.3",
+  "version": "2.3.0-rc.4",
   "description": "FRMS Center of Excellence startup package library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
bump lib version

## Why are we doing this?
avoid package conflicts

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [ ] Unit tests passing and Documentation done