### PR TITLE
fix: set frms-coe-startup-lib package to be public in the package.json to avoid unauthenticated errors during installations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lib"
   ],
   "publishConfig": {
-    "@tazama-lf:registry": "https://npm.pkg.github.com/"
+    "@tazama-lf:registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Set frms-coe-startup-lib package to be public in the package.json to avoid unauthenticated errors during installations.

## Why are we doing this?
- We have to add every individual who is trying to install Tazama full service either through a personal invitation or part of a team.
- For scoped packages (e.g., @scope/package-name), the default is "restricted". This means the package is private unless explicitly set to "public"

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done