### PR TITLE
build: dependency and version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",
         "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "5.1.1",
+        "@tazama-lf/frms-coe-lib": "^6.0.0-rc.5",
         "amqplib": "0.10.6",
         "axios": "^1.11.0",
         "google-auth-library": "^10.2.0",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "5.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.1.1/34ce71ad8006d8815f2048aba20fc4c674feb25b",
-      "integrity": "sha512-8Imeo6p5L2cOQC4nPc2qEUD05j8I2obIz3V+oeP2ao9PKEjNM75xVhLK3+TA2ikxI+p0P5/wSG5rxcJnWDVrTQ==",
+      "version": "6.0.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-rc.5/81e3adadd29e13e55de1ac3efe3e4922428dba34",
+      "integrity": "sha512-F9DNF+nXG793KnqdksgFu8VrjvWj326oXq685vKrMLpw4A7smAelwjlBUm04ZmOUzStsZ/tlftRynRQN7xSfTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-startup-lib",
-  "version": "2.4.1",
+  "version": "3.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-startup-lib",
-      "version": "2.4.1",
+      "version": "3.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-startup-lib",
-  "version": "2.4.1",
+  "version": "3.0.0-rc.0",
   "description": "Tazama startup package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "^8.1.1",
     "@google-cloud/storage": "^7.16.0",
-    "@tazama-lf/frms-coe-lib": "5.1.1",
+    "@tazama-lf/frms-coe-lib": "^6.0.0-rc.5",
     "amqplib": "0.10.6",
     "axios": "^1.11.0",
     "google-auth-library": "^10.2.0",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
`frms-coe-lib` version

## Why are we doing this?
To utilize multi-tenancy functionalities.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done