### PR TITLE
fix: bump fast-uri to 3.1.5 (CVE-2026-18446)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5078,9 +5078,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "overrides": {
     "uuid": "^11.1.1",
-    "@opentelemetry/core": "^2.8.0"
+    "@opentelemetry/core": "^2.8.0",
+    "fast-uri": "3.1.5"
   },
   "keywords": [],
   "author": "Tazama.org",


### PR DESCRIPTION
## Summary
- Bump transitive `fast-uri` to **3.1.5** to address [CVE-2026-18446](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / GHSA-7p8r-x3mc-p8w7.
- Targets `dev` (not `main`).

## Test plan
- [ ] CI green on this PR
- [ ] Confirm `package-lock.json` resolves `fast-uri@3.1.5`
- [ ] No unintended `package.json` dependency changes (override only if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to use `fast-uri` version 3.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->